### PR TITLE
Ajuste de imagen en historia

### DIFF
--- a/quienesSomos.html
+++ b/quienesSomos.html
@@ -299,7 +299,7 @@
 				<h4 class="text-center">Primer Reactivación</h4>
 				<p class="text-justify">En el año 2012 se realizó la primera reactivación de la rama estudiantil IEEE Unillanos, contando con la participación de la Ingeniera Monica Silva Quiceno, Egresada del programa Ingeniería Electrónica de la universidad de los Llanos, como Docente Consejero y en el liderazgo en la presidencia de Alejandro Huertas.</p>
 				<div class="text-center">
-					<img src="./assets/img/miembros_2012_R.jpg">
+					<img src="./assets/img/miembros_2012_R.jpg" style="width: 70%">
 				</div>
 				<p class="text-center">En la imágen se aprecia, a la izquierda, la ingeniera Monica Silva en compañía de los miembros de la rama en 2012.</p>
 				<p class="text-justify">En este periodo la rama IEEE Unillanos fue anfitrion de La IEEE Zona Centro, la cual es la reunión mensual de las ramas estudiantiles de la región, de con un total de 39 asistentes de Universidad Nacional De Colombia, Universidad Distrital Francisco Jose De Caldas, Universidad Autonoma De Colombia, Universidad De La Sabana. Universidad Pedagógica, Universidad Piloto De Colombia, Universidad San Buenaventura, Universidad Santo Tomas, todas de Bogotá y la Universidad Antonio Nariño de Villavicencio.</p>


### PR DESCRIPTION
Imagen de junta directiva en reactivación no se ajustaba al tamaño en pequeñas pantallas